### PR TITLE
Feature/past day check

### DIFF
--- a/src/Clockify/ClockifyController.cs
+++ b/src/Clockify/ClockifyController.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Bot.Remind;
 using Bot.Security;
@@ -38,6 +39,15 @@ namespace Bot.Clockify
             var typesToRemind = SpecificRemindService.ReminderType.YesterdayReminder |
                                 SpecificRemindService.ReminderType.TodayReminder;
 
+            bool respectWorkingHours = true;
+
+            //Check, whether we should disturb the employee even if it is the mid of the day
+            if (Request.Query.ContainsKey("respectWorkingHours"))
+            {
+                if (Request.Query["respectWorkingHours"].Contains("true")) respectWorkingHours = true;
+                if (Request.Query["respectWorkingHours"].Contains("false")) respectWorkingHours = false;
+            }
+
             //Check for additional query parameters. If there are available, we will only remind those reminders
             if (Request.Query.ContainsKey("type"))
             {
@@ -51,7 +61,7 @@ namespace Bot.Clockify
                     typesToRemind |= SpecificRemindService.ReminderType.TodayReminder;
             }
 
-            return await _entryFillRemindService.SendReminderAsync(_adapter, typesToRemind);
+            return await _entryFillRemindService.SendReminderAsync(_adapter, typesToRemind, respectWorkingHours);
         }
 
         [Route("api/follow-up")]

--- a/src/Clockify/ClockifyController.cs
+++ b/src/Clockify/ClockifyController.cs
@@ -36,8 +36,8 @@ namespace Bot.Clockify
             string apiToken = ProactiveApiKeyUtil.Extract(Request);
             _proactiveBotApiKeyValidator.Validate(apiToken);
 
-            var typesToRemind = SpecificRemindService.ReminderType.YesterdayReminder |
-                                SpecificRemindService.ReminderType.TodayReminder;
+            //Only use TodayReminder as default to be compatible to the old behaviour of the endpoint
+            var typesToRemind = SpecificRemindService.ReminderType.TodayReminder;
 
             bool respectWorkingHours = true;
 

--- a/src/Clockify/ClockifyController.cs
+++ b/src/Clockify/ClockifyController.cs
@@ -11,18 +11,18 @@ namespace Bot.Clockify
     public class ClockifyController : ControllerBase
     {
         private readonly IProactiveBotApiKeyValidator _proactiveBotApiKeyValidator;
-        private readonly IRemindService _entryFillRemindService;
+        private readonly ISpecificRemindService _entryFillRemindService;
         private readonly IBotFrameworkHttpAdapter _adapter;
         private readonly IFollowUpService _followUpService;
 
         public ClockifyController(IBotFrameworkHttpAdapter adapter,
-            IProactiveBotApiKeyValidator proactiveBotApiKeyValidator, IRemindServiceResolver remindServiceResolver,
+            IProactiveBotApiKeyValidator proactiveBotApiKeyValidator, ISpecificRemindServiceResolver specificRemindServiceResolver,
             IFollowUpService followUpService)
         {
             _adapter = adapter;
             _proactiveBotApiKeyValidator = proactiveBotApiKeyValidator;
             _followUpService = followUpService;
-            _entryFillRemindService = remindServiceResolver.Resolve("EntryFill");
+            _entryFillRemindService = specificRemindServiceResolver.Resolve("EntryFill");
         }
 
         [Route("api/timesheet/remind")]
@@ -32,7 +32,8 @@ namespace Bot.Clockify
             string apiToken = ProactiveApiKeyUtil.Extract(Request);
             _proactiveBotApiKeyValidator.Validate(apiToken);
 
-            return await _entryFillRemindService.SendReminderAsync(_adapter);
+            return await _entryFillRemindService.SendReminderAsync(_adapter,
+                SpecificRemindService.ReminderType.TodayReminder | SpecificRemindService.ReminderType.YesterdayReminder);
         }
 
         [Route("api/follow-up")]
@@ -42,7 +43,7 @@ namespace Bot.Clockify
             string apiToken = ProactiveApiKeyUtil.Extract(Request);
             _proactiveBotApiKeyValidator.Validate(apiToken);
 
-            var followedUsers =  await _followUpService.SendFollowUpAsync((BotAdapter)_adapter);
+            var followedUsers = await _followUpService.SendFollowUpAsync((BotAdapter)_adapter);
 
             return $"Sent follow up to {followedUsers.Count} users";
         }

--- a/src/Clockify/ClockifyMessageSource.cs
+++ b/src/Clockify/ClockifyMessageSource.cs
@@ -46,6 +46,8 @@ namespace Bot.Clockify
 
         public string RemindEntryFill => GetString(nameof(RemindEntryFill));
 
+        public string RemindEntryFillYesterday => GetString(nameof(RemindEntryFillYesterday));
+
         private string GetString(string name)
         {
             if (!_localizer[name].ResourceNotFound) return _localizer[name].Value;

--- a/src/Clockify/EntryFillRemindService.cs
+++ b/src/Clockify/EntryFillRemindService.cs
@@ -8,30 +8,14 @@ using Microsoft.Extensions.Logging;
 
 namespace Bot.Clockify
 {
-    public class EntryFillRemindService : GenericRemindService
+    public class EntryFillRemindService : SpecificRemindService
     {
-        private static BotCallbackHandler BotCallbackMaker(Func<string> getResource)
-        {
-            return async (turn, token) =>
-            {
-                string text = getResource();
-                if (Uri.IsWellFormedUriString(text, UriKind.RelativeOrAbsolute))
-                {
-                    // TODO: support other content types
-                    await turn.SendActivityAsync(MessageFactory.Attachment(new Attachment("image/png", text)), token);
-                }
-                else
-                {
-                    await turn.SendActivityAsync(MessageFactory.Text(text), token);
-                }
-            };
-        }
 
         public EntryFillRemindService(IUserProfilesProvider userProfilesProvider, IConfiguration configuration,
             ICompositeNeedReminderService compositeNeedRemindService, IClockifyMessageSource messageSource,
             ILogger<EntryFillRemindService> logger) :
             base(userProfilesProvider, configuration, compositeNeedRemindService,
-                BotCallbackMaker(() => messageSource.RemindEntryFill), logger)
+                messageSource, logger)
         {
         }
     }

--- a/src/Clockify/IClockifyMessageSource.cs
+++ b/src/Clockify/IClockifyMessageSource.cs
@@ -29,6 +29,8 @@
         string RemindStoppedAlready { get; }
         string RemindStopAnswer { get; }
         string RemindEntryFill { get; }
+        
+        string RemindEntryFillYesterday { get; }
 
         string FollowUp { get; }
     }

--- a/src/Clockify/PastDayNotComplete.cs
+++ b/src/Clockify/PastDayNotComplete.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Bot.Clockify.Client;
+using Bot.Common;
+using Bot.Data;
+using Bot.Remind;
+using Bot.States;
+
+namespace Bot.Clockify
+{
+    public class PastDayNotComplete : INeedRemindService
+    {
+        private readonly IClockifyService _clockifyService;
+        private readonly ITokenRepository _tokenRepository;
+        private readonly IDateTimeProvider _dateTimeProvider;
+
+        public PastDayNotComplete(IClockifyService clockifyService, ITokenRepository tokenRepository,
+            IDateTimeProvider dateTimeProvider)
+        {
+            _clockifyService = clockifyService;
+            _tokenRepository = tokenRepository;
+            _dateTimeProvider = dateTimeProvider;
+        }
+        
+        public async Task<bool> ReminderIsNeeded(UserProfile userProfile)
+        {
+            try
+            {
+                var tokenData = await _tokenRepository.ReadAsync(userProfile.ClockifyTokenId!);
+                string clockifyToken = tokenData.Value;
+                string userId = userProfile.UserId ?? throw new ArgumentNullException(nameof(userProfile.UserId));
+                var workspaces = await _clockifyService.GetWorkspacesAsync(clockifyToken);
+
+                TimeZoneInfo userTimeZone = userProfile.TimeZone;
+                var userNow = TimeZoneInfo.ConvertTime(_dateTimeProvider.DateTimeUtcNow(), userTimeZone);
+
+                var userStartDay = userNow.Date.AddDays(-1); //Get past day
+
+                //Check for weekends. If we got one, go back in time. 
+                while (userStartDay.DayOfWeek == DayOfWeek.Sunday || userStartDay.DayOfWeek == DayOfWeek.Saturday)
+                {
+                    userStartDay = userStartDay.AddDays(-1); //Go back in time till we have no weekend anymore
+                }
+                var userEndDay = userStartDay.AddDays(1); //Add one day to the startDay for a 1 day range
+
+                double totalHoursInserted = (await Task.WhenAll(workspaces.Select(ws =>
+                        _clockifyService.GetHydratedTimeEntriesAsync(clockifyToken, ws.Id, userId, userStartDay,
+                            userEndDay))))
+                    .SelectMany(p => p)
+                    .Sum(e =>
+                    {
+                        if (e.TimeInterval.End != null && e.TimeInterval.Start != null)
+                        {
+                            return (e.TimeInterval.End.Value - e.TimeInterval.Start.Value).TotalHours;
+                        }
+
+                        return 0;
+                    });
+                return totalHoursInserted < 6;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/src/Clockify/Reports/ReportUtil.cs
+++ b/src/Clockify/Reports/ReportUtil.cs
@@ -51,7 +51,7 @@ namespace Bot.Clockify.Reports
         public static string FormatDuration(float duration)
         {
             double days = duration / 8.0;
-            return $"{days:0.00}d ({duration:0.00}h)";
+            return $"{days:0.00}d";
         }
 
         private static float DurationInDecimal(HydratedTimeEntryDo hydratedTimeEntry)

--- a/src/Common/Resources/Clockify.ClockifyMessageSource.resx
+++ b/src/Common/Resources/Clockify.ClockifyMessageSource.resx
@@ -157,4 +157,7 @@ Please don't exceed one year window</value>
     <data name="FollowUp" xml:space="preserve">
         <value>Hey 👋 I noticed you never setup a Clockify token...{0}{0}Help me help you! Once you're setup I will assist you in your daily time tracking.</value>
     </data>
+    <data name="RemindEntryFillYesterday_1" xml:space="preserve">
+        <value>You have not filled in all of your hours for yesterday. Please do so!</value>
+    </data>
 </root>

--- a/src/Remind/CompositeNeedReminderService.cs
+++ b/src/Remind/CompositeNeedReminderService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Bot.Clockify;
+using Bot.DIC;
 using Bot.States;
 
 namespace Bot.Remind
@@ -34,30 +35,19 @@ namespace Bot.Remind
                 //Check if the particular reminder was set to true
                 if (reminderIsNeeded)
                 {
-                    if (service.GetType() == typeof(PastDayNotComplete) ||
-                        service.GetType() == typeof(TimeSheetNotFullEnough))
-                    {
-                        if (service.GetType() == typeof(PastDayNotComplete)) reminder |= SpecificRemindService.ReminderType.YesterdayReminder;
-                        if (service.GetType() == typeof(TimeSheetNotFullEnough)) reminder |= SpecificRemindService.ReminderType.TodayReminder;
-                    }
+                    //The reminder for this service is needed, check why it is needed and set the flags
+                    if (service.GetType() == typeof(PastDayNotComplete)) reminder |= SpecificRemindService.ReminderType.YesterdayReminder;
+                    if (service.GetType() == typeof(TimeSheetNotFullEnough)) reminder |= SpecificRemindService.ReminderType.TodayReminder;
                 }
                 else
                 {
-                    //As soon as one reminder check was negative, we return "NoReminder" since all checks needs to be true!
-                    //TODO not always break! We can remind for yesterdays times even if it is early morning!
-                    return SpecificRemindService.ReminderType.NoReminder;
+                    //The reminder for this service is not needed. Therefore we check, what was negative and set the appropriate flag!
+                    if (service.GetType() == typeof(EndOfWorkingDay)) reminder |= SpecificRemindService.ReminderType.OutOfWorkTime;
+                    if (service.GetType() == typeof(UserDidNotSayStop)) reminder |= SpecificRemindService.ReminderType.UserSaidStop;
+                    if (service.GetType() == typeof(NotOnLeave)) reminder |= SpecificRemindService.ReminderType.UserOnLeave;
                 }
             }
-            
             return reminder;
-
-            // foreach (var service in _services.Select(service => service.ReminderIsNeeded(profile)))
-            // {
-            //     
-            // }
-            //
-            // bool[] conditions = await Task.WhenAll(_services.Select(service => service.ReminderIsNeeded(profile)));
-            // return conditions.All(c => c);
         }
     }
 }

--- a/src/Remind/CompositeNeedReminderService.cs
+++ b/src/Remind/CompositeNeedReminderService.cs
@@ -1,13 +1,15 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Bot.Clockify;
 using Bot.States;
 
 namespace Bot.Remind
 {
     public interface ICompositeNeedReminderService
     {
-        Task<bool> ReminderIsNeeded(UserProfile profile);
+        Task<SpecificRemindService.ReminderType> ReminderIsNeeded(UserProfile profile);
     }
     
     public class CompositeNeedReminderService: ICompositeNeedReminderService
@@ -19,10 +21,43 @@ namespace Bot.Remind
             _services = services;
         }
 
-        public async Task<bool> ReminderIsNeeded(UserProfile profile)
+        public async Task<SpecificRemindService.ReminderType> ReminderIsNeeded(UserProfile profile)
         {
-            bool[] conditions = await Task.WhenAll(_services.Select(service => service.ReminderIsNeeded(profile)));
-            return conditions.All(c => c);
+            var reminder = SpecificRemindService.ReminderType.NoReminder;
+            
+            //Check every reminder within all services
+            foreach (var service in _services)
+            {
+                var serviceType = typeof(PastDayNotComplete);
+                var reminderIsNeeded = await service.ReminderIsNeeded(profile);
+
+                //Check if the particular reminder was set to true
+                if (reminderIsNeeded)
+                {
+                    if (service.GetType() == typeof(PastDayNotComplete) ||
+                        service.GetType() == typeof(TimeSheetNotFullEnough))
+                    {
+                        if (service.GetType() == typeof(PastDayNotComplete)) reminder |= SpecificRemindService.ReminderType.YesterdayReminder;
+                        if (service.GetType() == typeof(TimeSheetNotFullEnough)) reminder |= SpecificRemindService.ReminderType.TodayReminder;
+                    }
+                }
+                else
+                {
+                    //As soon as one reminder check was negative, we return "NoReminder" since all checks needs to be true!
+                    //TODO not always break! We can remind for yesterdays times even if it is early morning!
+                    return SpecificRemindService.ReminderType.NoReminder;
+                }
+            }
+            
+            return reminder;
+
+            // foreach (var service in _services.Select(service => service.ReminderIsNeeded(profile)))
+            // {
+            //     
+            // }
+            //
+            // bool[] conditions = await Task.WhenAll(_services.Select(service => service.ReminderIsNeeded(profile)));
+            // return conditions.All(c => c);
         }
     }
 }

--- a/src/Remind/GenericRemindService.cs
+++ b/src/Remind/GenericRemindService.cs
@@ -37,13 +37,14 @@ namespace Bot.Remind
         {
             var reminderCounter = 0;
 
-            async Task<bool> ReminderNeeded(UserProfile u) => await _compositeNeedRemindService.ReminderIsNeeded(u);
+            async Task<SpecificRemindService.ReminderType> ReminderNeeded(UserProfile u) => await _compositeNeedRemindService.ReminderIsNeeded(u);
 
             List<UserProfile> userProfiles = await _userProfilesProvider.GetUserProfilesAsync();
 
+            //Fetch all users where the ReminderType is not set to "NoReminder"
             List<UserProfile> userToRemind = userProfiles
                 .Where(u => u.ClockifyTokenId != null && u.ConversationReference != null)
-                .Where(u => ReminderNeeded(u).Result)
+                .Where(u => ReminderNeeded(u).Result != SpecificRemindService.ReminderType.NoReminder)
                 .ToList();
 
             foreach (var userProfile in userToRemind)

--- a/src/Remind/ISpecificRemindService.cs
+++ b/src/Remind/ISpecificRemindService.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+
+namespace Bot.Remind
+{
+    public interface ISpecificRemindService
+    {
+        Task<string> SendReminderAsync(IBotFrameworkHttpAdapter adapter, SpecificRemindService.ReminderType reminderTypes);
+    }
+}

--- a/src/Remind/ISpecificRemindService.cs
+++ b/src/Remind/ISpecificRemindService.cs
@@ -5,6 +5,7 @@ namespace Bot.Remind
 {
     public interface ISpecificRemindService
     {
-        Task<string> SendReminderAsync(IBotFrameworkHttpAdapter adapter, SpecificRemindService.ReminderType reminderTypes);
+        Task<string> SendReminderAsync(IBotFrameworkHttpAdapter adapter, SpecificRemindService.ReminderType reminderTypes,
+            bool respectWorkHours);
     }
 }

--- a/src/Remind/SpecificRemindService.cs
+++ b/src/Remind/SpecificRemindService.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Bot.Clockify;
+using Bot.States;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Bot.Remind
+{
+    public abstract class SpecificRemindService : ISpecificRemindService
+    {
+        private readonly IUserProfilesProvider _userProfilesProvider;
+        private readonly IClockifyMessageSource _messageSource;
+        private readonly ICompositeNeedReminderService _compositeNeedRemindService;
+        private readonly string _appId;
+        private readonly ILogger _logger;
+
+        private static BotCallbackHandler BotCallbackMaker(Func<string> getResource)
+        {
+            return async (turn, token) =>
+            {
+                string text = getResource();
+                if (Uri.IsWellFormedUriString(text, UriKind.RelativeOrAbsolute))
+                {
+                    // TODO: support other content types
+                    await turn.SendActivityAsync(MessageFactory.Attachment(new Attachment("image/png", text)), token);
+                }
+                else
+                {
+                    await turn.SendActivityAsync(MessageFactory.Text(text), token);
+                }
+            };
+        }
+
+        protected SpecificRemindService(IUserProfilesProvider userProfilesProvider, IConfiguration configuration,
+            ICompositeNeedReminderService compositeNeedReminderService, IClockifyMessageSource messageSource,
+            ILogger logger)
+        {
+            _userProfilesProvider = userProfilesProvider;
+            _compositeNeedRemindService = compositeNeedReminderService;
+            _messageSource = messageSource;
+            _logger = logger;
+            _appId = configuration["MicrosoftAppId"];
+            if (string.IsNullOrEmpty(_appId))
+            {
+                _appId = Guid.NewGuid().ToString();
+            }
+        }
+
+        [Flags]
+        public enum ReminderType
+        {
+            NoReminder = 0,
+            TodayReminder = 1,
+            YesterdayReminder = 2,
+            WeekReminder = 4,
+            DicReminder = 8
+        };
+
+
+        private bool SendSpecificReminderType(IBotFrameworkHttpAdapter adapter, UserProfile userProfile,
+            ReminderType reminderType)
+        {
+            var callback = BotCallbackMaker(() => _messageSource.RemindEntryFill);
+            switch (reminderType)
+            {
+                case ReminderType.TodayReminder:
+                    callback = BotCallbackMaker(() => _messageSource.RemindEntryFill);
+                    break;
+
+                case ReminderType.YesterdayReminder:
+                    callback = BotCallbackMaker(() => _messageSource.RemindEntryFillYesterday);
+                    break;
+            }
+
+            try
+            {
+                //TODO Change _botCallback according to the reminder type
+                ((BotAdapter)adapter).ContinueConversationAsync(
+                    _appId,
+                    userProfile!.ConversationReference,
+                    callback,
+                    default).Wait(1000);
+            }
+            catch (Exception e)
+            {
+                // Just logging the exception is sufficient, we do not want to stop other reminders.
+                _logger.LogError(e, "Reminder not sent for user {UserId}", userProfile.UserId);
+                return false;
+            }
+
+            return true;
+        }
+
+        public async Task<string> SendReminderAsync(IBotFrameworkHttpAdapter adapter, ReminderType reminderTypes)
+        {
+            var reminderCounter = 0;
+            //Check, whether we need to remind at least one event
+            if (reminderTypes != ReminderType.NoReminder)
+            {
+                async Task<ReminderType> ReminderNeeded(UserProfile u) =>
+                    await _compositeNeedRemindService.ReminderIsNeeded(u);
+
+                List<UserProfile> userProfiles = await _userProfilesProvider.GetUserProfilesAsync();
+
+                //Search for all users where a reminder was set to something else than "NoReminder"
+                List<UserProfile> validUsers = userProfiles
+                    .Where(u => u.ClockifyTokenId != null && u.ConversationReference != null)
+                    .ToList();
+
+                foreach (var userProfile in validUsers)
+                {
+                    var userReminderTypes = ReminderNeeded(userProfile).Result;
+
+                    //Check if we need to remind the user
+                    if (userReminderTypes != ReminderType.NoReminder)
+                    {
+                        //Switch between the different reminder types
+                        switch (userReminderTypes)
+                        {
+                            case ReminderType.TodayReminder:
+                                if (SendSpecificReminderType(adapter, userProfile, ReminderType.TodayReminder))
+                                    reminderCounter++;
+                                break;
+
+                            case ReminderType.YesterdayReminder:
+                                if (SendSpecificReminderType(adapter, userProfile, ReminderType.YesterdayReminder))
+                                    reminderCounter++;
+                                break;
+                        }
+                    }
+                }
+            }
+            return $"Sent reminder to {reminderCounter} users";
+        }
+
+    }
+}

--- a/src/Remind/SpecificRemindService.cs
+++ b/src/Remind/SpecificRemindService.cs
@@ -59,7 +59,9 @@ namespace Bot.Remind
             TodayReminder = 1,
             YesterdayReminder = 2,
             WeekReminder = 4,
-            DicReminder = 8
+            OutOfWorkTime = 8,
+            UserSaidStop = 16,
+            UserOnLeave = 32
         };
 
 

--- a/src/Remind/SpecificRemindService.cs
+++ b/src/Remind/SpecificRemindService.cs
@@ -99,7 +99,8 @@ namespace Bot.Remind
             return true;
         }
 
-        public async Task<string> SendReminderAsync(IBotFrameworkHttpAdapter adapter, ReminderType typesToRemind)
+        public async Task<string> SendReminderAsync(IBotFrameworkHttpAdapter adapter, ReminderType typesToRemind,
+            bool respectWorkHours)
         {
             var reminderCounter = 0;
             var userCounter = 0;
@@ -123,8 +124,15 @@ namespace Bot.Remind
                     //Check if we need to remind the user
                     if (userReminderTypes != ReminderType.NoReminder)
                     {
-                        userCounter++;
+                        //Check if we are out of working hours and we also want to check for this, break.
+                        if (userReminderTypes.HasFlag(ReminderType.OutOfWorkTime) && respectWorkHours)
+                        {
+                            break;
+                        }
                         
+                        //Only upcount for users, which are not affected by the "OutOfWorkTime" condition
+                        userCounter++;
+
                         //Check, if the user needs a reminder for today and if we also have requested a reminder for today.
                         if (userReminderTypes.HasFlag(ReminderType.TodayReminder) &&
                             typesToRemind.HasFlag(ReminderType.TodayReminder))

--- a/src/Remind/SpecificRemindServiceResolver.cs
+++ b/src/Remind/SpecificRemindServiceResolver.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Bot.Remind
+{
+    public interface ISpecificRemindServiceResolver
+    {
+        ISpecificRemindService Resolve(string name);
+    }
+    
+    public class SpecificRemindServiceResolver: ISpecificRemindServiceResolver
+    {
+        private readonly IEnumerable<ISpecificRemindService> _remindServices;
+
+        public SpecificRemindServiceResolver(IEnumerable<ISpecificRemindService> remindServices)
+        {
+            _remindServices = remindServices;
+        }
+
+        public ISpecificRemindService Resolve(string name)
+        {
+            return _remindServices.Single(p => p.GetType().ToString().Contains(name));
+        }
+    }
+}

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -81,6 +81,7 @@ namespace Bot
             services.AddSingleton<INeedRemindService, TimeSheetNotFullEnough>();
             services.AddSingleton<INeedRemindService, UserDidNotSayStop>();
             services.AddSingleton<INeedRemindService, NotOnLeave>();
+            services.AddSingleton<INeedRemindService, PastDayNotComplete>();
             services.AddSingleton<ICompositeNeedReminderService, CompositeNeedReminderService>();
             services.AddSingleton<IRemindService, EntryFillRemindService>();
             services.AddSingleton<IRemindService, SmartWorkingRemindService>();

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -83,7 +83,8 @@ namespace Bot
             services.AddSingleton<INeedRemindService, NotOnLeave>();
             services.AddSingleton<INeedRemindService, PastDayNotComplete>();
             services.AddSingleton<ICompositeNeedReminderService, CompositeNeedReminderService>();
-            services.AddSingleton<IRemindService, EntryFillRemindService>();
+            services.AddSingleton<ISpecificRemindService, EntryFillRemindService>();
+            services.AddSingleton<ISpecificRemindServiceResolver, SpecificRemindServiceResolver>();
             services.AddSingleton<IRemindService, SmartWorkingRemindService>();
             services.AddSingleton<IRemindServiceResolver, RemindServiceResolver>();
             services.AddSingleton<IFollowUpService, FollowUpService>();


### PR DESCRIPTION
I have added the possibility to also check the previous day. The "PastDayNotComplete" class also takes into account wheter the past day was a weekend or not. If so, the past friday will be checked instead of sunday.

I have also extended the endpoint /api/timesheet/remind with additional parameters to specify what needs to be checked.

Without adding anything, the behaviour will be the exact same as it was before. Just checking for todays work and also respecting the working hours.

To be able to remind a user during the day for the badness of not adding the hours yesterday, we must be able to not respect the working hours and remind him also during the day. Therefore i added the "respectWorkingHours" variable and also the parameters.

This is, how one can now trigger the endpoint:

This will remind him for todays and yesterdays hours without respecting the working hours
api/timesheet/remind?type=yesterday&type=today&respectWorkingHours=false

This will remind him for todays hours and also for yesterdays while respecting the working hours
api/timesheet/remind?type=yesterday&type=today

This will remind him for todays hours only while respecting the working hours
api/timesheet/remind?type=today