### PR TITLE
Added user specific working hours

### DIFF
--- a/src/Clockify/ClockifyHandler.cs
+++ b/src/Clockify/ClockifyHandler.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Bot.Clockify.Fill;
 using Bot.Clockify.Reports;
+using Bot.Clockify.User;
 using Bot.Common.Recognizer;
 using Bot.States;
 using Bot.Supports;
@@ -15,23 +16,26 @@ namespace Bot.Clockify
     {
         private readonly EntryFillDialog _fillDialog;
         private readonly ReportDialog _reportDialog;
+        private readonly UserSettingsDialog _userSettingsDialog;
         private readonly StopReminderDialog _stopReminderDialog;
         private readonly ClockifySetupDialog _clockifySetupDialog;
         private readonly DialogSet _dialogSet;
         private readonly IStatePropertyAccessor<DialogState> _dialogState;
 
         public ClockifyHandler(EntryFillDialog fillDialog, ReportDialog reportDialog,
-            StopReminderDialog stopReminderDialog, ConversationState conversationState,
+            StopReminderDialog stopReminderDialog, UserSettingsDialog userSettingsDialog, ConversationState conversationState,
             ClockifySetupDialog clockifySetupDialog)
         {
             _dialogState = conversationState.CreateProperty<DialogState>("ClockifyDialogState");
             _fillDialog = fillDialog;
             _reportDialog = reportDialog;
+            _userSettingsDialog = userSettingsDialog;
             _stopReminderDialog = stopReminderDialog;
             _clockifySetupDialog = clockifySetupDialog;
             _dialogSet = new DialogSet(_dialogState)
                 .Add(_fillDialog)
                 .Add(_stopReminderDialog)
+                .Add(_userSettingsDialog)
                 .Add(_reportDialog)
                 .Add(_clockifySetupDialog);
         }
@@ -52,6 +56,9 @@ namespace Bot.Clockify
             {
                 switch (luisResult.TopIntentWithMinScore())
                 {
+                    case TimeSurveyBotLuis.Intent.SetWorkingHours:
+                        await dialogContext.BeginDialogAsync(_userSettingsDialog.Id, luisResult, cancellationToken);
+                        return true;
                     case TimeSurveyBotLuis.Intent.Report:
                         await dialogContext.BeginDialogAsync(_reportDialog.Id, luisResult, cancellationToken);
                         return true;

--- a/src/Clockify/ClockifyMessageSource.cs
+++ b/src/Clockify/ClockifyMessageSource.cs
@@ -24,6 +24,8 @@ namespace Bot.Clockify
         public string TaskCreation => GetString(nameof(TaskCreation));
         public string TaskAbort => GetString(nameof(TaskAbort));
         public string AddEntryFeedback => GetString(nameof(AddEntryFeedback));
+        public string SetWorkingHoursFeedback => GetString(nameof(SetWorkingHoursFeedback));
+        public string SetWorkingHoursUnchangedFeedback => GetString(nameof(SetWorkingHoursUnchangedFeedback));
         public string EntryFillUnderstandingError => GetString(nameof(EntryFillUnderstandingError));
         public string AmbiguousProjectError => GetString(nameof(AmbiguousProjectError));
         public string ProjectUnrecognized => GetString(nameof(ProjectUnrecognized));

--- a/src/Clockify/IClockifyMessageSource.cs
+++ b/src/Clockify/IClockifyMessageSource.cs
@@ -11,6 +11,8 @@
         string TaskCreation { get; }
         string TaskAbort { get; }
         string AddEntryFeedback { get; }
+        string SetWorkingHoursFeedback { get; }
+        string SetWorkingHoursUnchangedFeedback { get; }
         string EntryFillUnderstandingError { get; }
         string AmbiguousProjectError { get; }
         string ProjectUnrecognized { get; }

--- a/src/Clockify/TimeSheetNotFullEnough.cs
+++ b/src/Clockify/TimeSheetNotFullEnough.cs
@@ -15,6 +15,15 @@ namespace Bot.Clockify
         private readonly ITokenRepository _tokenRepository;
         private readonly IDateTimeProvider _dateTimeProvider;
 
+        //Get de default hours to work. If not defined, assume 8hours
+        public static readonly string DefaultWorkingHours =
+            Environment.GetEnvironmentVariable("DEFAULT_WORKING_HOURS") ?? "8";
+
+        //Get the minimum percentage of hours filled. If not defined, assume 75% of a default work day to be reported.
+        //This leads to 6 hours
+        public static readonly string MinimumHoursFilledPercentage =
+            Environment.GetEnvironmentVariable("MINIMUM_HOURS_FILLED_PERCENTAGE") ?? "75";
+
         public TimeSheetNotFullEnough(IClockifyService clockifyService, ITokenRepository tokenRepository,
             IDateTimeProvider dateTimeProvider)
         {
@@ -50,7 +59,15 @@ namespace Bot.Clockify
 
                         return 0;
                     });
-                return totalHoursInserted < 6;
+
+                //Check if we have defined the working hours on user level. If so, calculate the minimum.
+                if (userProfile.WorkingHours != null)
+                    return totalHoursInserted <
+                           (userProfile.WorkingHours * (double.Parse(MinimumHoursFilledPercentage) / 100));
+                
+                //Calculate the minimum amount of hours to be reported based on the defaults.
+                return totalHoursInserted < (double.Parse(DefaultWorkingHours) *
+                                             (double.Parse(MinimumHoursFilledPercentage) / 100));
             }
             catch (Exception)
             {

--- a/src/Clockify/User/UserSettingsDialog.cs
+++ b/src/Clockify/User/UserSettingsDialog.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Bot.Clockify.Client;
+using Bot.Clockify.Fill;
+using Bot.Clockify.Models;
+using Bot.Common;
+using Bot.Common.ChannelData.Telegram;
+using Bot.Common.Recognizer;
+using Bot.Data;
+using Bot.States;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Bot.Clockify.User
+{
+    public class UserSettingsDialog : ComponentDialog
+    {
+        private readonly ITokenRepository _tokenRepository;
+        private readonly ITimeEntryStoreService _timeEntryStoreService;
+        private readonly UserState _userState;
+        private readonly IClockifyMessageSource _messageSource;
+        private readonly IDateTimeProvider _dateTimeProvider;
+        private readonly ILogger<UserSettingsDialog> _logger;
+
+        private const string TaskWaterfall = "TaskWaterfall";
+
+        private const string Telegram = "telegram";
+
+        public UserSettingsDialog(ITimeEntryStoreService timeEntryStoreService,
+            UserState userState, ITokenRepository tokenRepository,
+            IClockifyMessageSource messageSource, IDateTimeProvider dateTimeProvider,
+            ILogger<UserSettingsDialog> logger)
+        {
+            _timeEntryStoreService = timeEntryStoreService;
+            _userState = userState;
+            _tokenRepository = tokenRepository;
+            _messageSource = messageSource;
+            _dateTimeProvider = dateTimeProvider;
+            _logger = logger;
+            AddDialog(new WaterfallDialog(TaskWaterfall, new List<WaterfallStep>
+            {
+                PromptForTaskAsync
+            }));
+            Id = nameof(UserSettingsDialog);
+        }
+
+        private async Task<DialogTurnResult> PromptForTaskAsync(WaterfallStepContext stepContext,
+            CancellationToken cancellationToken)
+        {
+            string messageText = "";
+
+            var userProfile =
+                await StaticUserProfileHelper.GetUserProfileAsync(_userState, stepContext.Context, cancellationToken);
+            var tokenData = await _tokenRepository.ReadAsync(userProfile.ClockifyTokenId!);
+            string clockifyToken = tokenData.Value;
+            stepContext.Values["ClockifyTokenId"] = userProfile.ClockifyTokenId;
+            var luisResult = (TimeSurveyBotLuis)stepContext.Options;
+
+            var workingMinutes = luisResult.WorkedDurationInMinutes();
+            var workingHours = workingMinutes / 60;
+
+            //Default messageText
+            messageText = string.Format(_messageSource.SetWorkingHoursFeedback, workingHours);
+            
+            //Check if there is a need for a change
+            if (userProfile.WorkingHours != null)
+            {
+                if (userProfile.WorkingHours == workingHours)
+                    messageText = string.Format(_messageSource.SetWorkingHoursUnchangedFeedback, workingHours);
+            }
+
+            //Store the working hours within the userProfile
+            userProfile.WorkingHours = workingHours;
+            
+            //Inform user and exit the conversation.
+            return await InformAndExit(stepContext, cancellationToken, messageText);
+        }
+
+
+        private async Task<DialogTurnResult> InformAndExit(DialogContext stepContext,
+            CancellationToken cancellationToken, string messageText)
+        {
+            string platform = stepContext.Context.Activity.ChannelId;
+            var ma = GetExitMessageActivity(messageText, platform);
+            await stepContext.Context.SendActivityAsync(ma, cancellationToken);
+            return await stepContext.EndDialogAsync(cancellationToken: cancellationToken);
+        }
+
+
+        private static IMessageActivity GetExitMessageActivity(string messageText, string platform)
+        {
+            IMessageActivity ma;
+            switch (platform.ToLower())
+            {
+                case Telegram:
+                    ma = Activity.CreateMessageActivity();
+                    var sendMessageParams = new SendMessageParameters(messageText, new ReplyKeyboardRemove());
+                    var channelData = new SendMessage(sendMessageParams);
+                    ma.ChannelData = JsonConvert.SerializeObject(channelData);
+                    return ma;
+                default:
+                    ma = MessageFactory.Text(messageText);
+                    ma.SuggestedActions = new SuggestedActions { Actions = new List<CardAction>() };
+                    return ma;
+            }
+
+            ;
+        }
+    }
+}

--- a/src/Common/Recognizer/TimeSurveyBotLuis.cs
+++ b/src/Common/Recognizer/TimeSurveyBotLuis.cs
@@ -29,7 +29,8 @@ namespace Bot.Common.Recognizer
             Report,
             Thanks,
             Utilities_Help,
-            Utilities_Stop
+            Utilities_Stop,
+            SetWorkingHours
         };
         [JsonProperty("intents")]
         public Dictionary<Intent, IntentScore> Intents;

--- a/src/Common/Resources/Clockify.ClockifyMessageSource.resx
+++ b/src/Common/Resources/Clockify.ClockifyMessageSource.resx
@@ -160,4 +160,10 @@ Please don't exceed one year window</value>
     <data name="RemindEntryFillYesterday_1" xml:space="preserve">
         <value>You have not filled in all of your hours for yesterday. Please do so!</value>
     </data>
+    <data name="SetWorkingHoursFeedback" xml:space="preserve">
+        <value>Ok, I set your daily working hours to {0:0} hours. Happy working 🤖</value>
+    </data>
+    <data name="SetWorkingHoursUnchangedFeedback" xml:space="preserve">
+        <value>Your daily working hours were already set to {0:0} hours 😅. Nothing changed.</value>
+    </data>
 </root>

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -6,6 +6,7 @@ using Bot.Clockify;
 using Bot.Clockify.Client;
 using Bot.Clockify.Fill;
 using Bot.Clockify.Reports;
+using Bot.Clockify.User;
 using Bot.Common;
 using Bot.Common.Recognizer;
 using Bot.Data;
@@ -62,6 +63,7 @@ namespace Bot
             services.AddSingleton<IReportSummaryService, ReportSummaryService>();
             services.AddSingleton<IReportExtractor, ReportExtractor>();
             services.AddSingleton<EntryFillDialog>();
+            services.AddSingleton<UserSettingsDialog>();
             services.AddSingleton<StopReminderDialog>();
             services.AddSingleton<WorthAskingForTaskService>();
             services.AddSingleton<ITimeEntryStoreService, TimeEntryStoreService>();

--- a/src/States/UserProfile.cs
+++ b/src/States/UserProfile.cs
@@ -20,6 +20,8 @@ namespace Bot.States
         public string? LastName { get; set; }
         
         public ConversationReference? ConversationReference { get; set; }
+        
+        public double? WorkingHours { get; set; }
 
         public DateTime? StopRemind { get; set; }
         public bool Experimental { get; set; }


### PR DESCRIPTION
Hi there

This feature provides the ability to store the target working hours within the user profile. 
The user can also set its own working hours using LUIS with something like: 

"change my work hours to 8 hours". 

The important part is, that LUIS only recognizes one time. 
Cause i am using the WorkedDurationInMinutes method which will fail if a sentence like this will be used: 

"my day has 9 hours" cause "WorkedDurationInMinutes" takes the first() element which will be a date instead of hours. 

Additionaly to that, i have added two now environment variables: 

`DEFAULT_WORKING_HOURS
MINIMUM_HOURS_FILLED_PERCENTAGE
`

The idea is the following: one can define a standard workday duration and also a minimum percentage of what needs to be reported till 5 PM. 

I wrote the code in a way that the defaults are 8 hours and 75% if no environment variable has been set. 
This way all existing setups will work also with this code
