### PR TITLE
Added persistent local storage for testing / development

### DIFF
--- a/src/Data/InMemoryTokenRepository.cs
+++ b/src/Data/InMemoryTokenRepository.cs
@@ -1,16 +1,26 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.IO;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace Bot.Data
 {
     public class InMemoryTokenRepository : ITokenRepository
     {
-        private readonly ConcurrentDictionary<string, string> _store = new ConcurrentDictionary<string, string>();
+        private ConcurrentDictionary<string, string> _store = new ConcurrentDictionary<string, string>();
+        
 
         public Task<TokenData> ReadAsync(string id)
         {
             if (id == null) throw new ArgumentNullException(id);
+
+            //If local storage exists, load it!
+            if (File.Exists("jsonStorage.json"))
+            {
+                var jsonStorage = File.ReadAllText("jsonStorage.json");
+                _store = JsonConvert.DeserializeObject<ConcurrentDictionary<String, String>>(jsonStorage);
+            }
 
             if (!_store.TryGetValue(id, out var value))
             {
@@ -25,6 +35,8 @@ namespace Bot.Data
 
             string name = id ?? Guid.NewGuid().ToString();
             _store.AddOrUpdate(name, value, (key, current) => value);
+            var jsonStorage = JsonConvert.SerializeObject(_store);
+            File.WriteAllText("jsonStorage.json",jsonStorage);
             return Task.FromResult(new TokenData(name, value));
         }
     }


### PR DESCRIPTION
Hi

During the development i found it quite handy to have a persistent storage for the token to not always set the token after a restart of the server.

This pull request will enable the bot to store the tokens inside of a json.